### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,6 +40,6 @@ p6df::modules::nmap::external::brews() {
 p6df::modules::nmap::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'nmap' "$"
+  p6_return_words 'nmap' "$NMAP_PRIVILEGED"
 }
 

--- a/init.zsh
+++ b/init.zsh
@@ -39,6 +39,7 @@ p6df::modules::nmap::external::brews() {
 ######################################################################
 p6df::modules::nmap::profile::mod() {
 
-  p6_return_words 'nmap' '$NMAP_PRIVILEGED'
+  # shellcheck disable=SC2016
+  p6_return_words 'nmap' "$"
 }
 

--- a/init.zsh
+++ b/init.zsh
@@ -25,3 +25,20 @@ p6df::modules::nmap::external::brews() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words nmap $NMAP_PRIVILEGED = p6df::modules::nmap::profile::mod()
+#
+#  Returns:
+#	words - nmap $NMAP_PRIVILEGED
+#
+#  Environment:	 NMAP_PRIVILEGED
+#>
+######################################################################
+p6df::modules::nmap::profile::mod() {
+
+  p6_return_words 'nmap' '$NMAP_PRIVILEGED'
+}
+


### PR DESCRIPTION
## What
Add `profile::mod` to p6df-nmap using `p6_return_words` with word and variable as separate quoted arguments.

## Why
Consistent quoting convention for `p6_return_words` calls across all p6df modules.

## Test plan
- Verify `p6df::modules::nmap::profile::mod` returns two words: `nmap` and the value of `$NMAP_PRIVILEGED`
- Load module in zsh and confirm no errors

## Dependencies
None