### PR TITLE
fix(nmap): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,6 +40,6 @@ p6df::modules::nmap::external::brews() {
 p6df::modules::nmap::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'nmap' "$NMAP_PRIVILEGED"
+  p6_return_words 'nmap' '$NMAP_PRIVILEGED'
 }
 


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None